### PR TITLE
Fix forbidden update by considering only mutable fields

### DIFF
--- a/commons/src/main/java/com/pryv/connection/ConnectionAccesses.java
+++ b/commons/src/main/java/com/pryv/connection/ConnectionAccesses.java
@@ -39,7 +39,8 @@ public class ConnectionAccesses {
     }
 
     public Access update(Access updateAccess) throws IOException {
-        HttpClient.ApiResponse apiResponse = httpClient.updateRequest(PATH, updateAccess.getId(), updateAccess).exec();
+        Access update = updateAccess.cloneMutableFields();
+        HttpClient.ApiResponse apiResponse = httpClient.updateRequest(PATH, updateAccess.getId(), update).exec();
         Access updatedAccess = JsonConverter.retrieveResourceFromJson(apiResponse.getJsonBody(), ACCESS_KEY, Access.class);
         return updatedAccess;
     }

--- a/commons/src/main/java/com/pryv/connection/ConnectionEvents.java
+++ b/commons/src/main/java/com/pryv/connection/ConnectionEvents.java
@@ -55,7 +55,8 @@ public class ConnectionEvents {
     }
 
     public Event update(Event updateEvent) throws IOException {
-        HttpClient.ApiResponse apiResponse = httpClient.updateRequest(PATH, updateEvent.getId(), updateEvent).exec();
+        Event update = updateEvent.cloneMutableFields();
+        HttpClient.ApiResponse apiResponse = httpClient.updateRequest(PATH, updateEvent.getId(), update).exec();
         Event updatedEvent = JsonConverter.retrieveEventFromJson(apiResponse.getJsonBody());
         return updatedEvent;
     }

--- a/commons/src/main/java/com/pryv/connection/ConnectionStreams.java
+++ b/commons/src/main/java/com/pryv/connection/ConnectionStreams.java
@@ -58,7 +58,8 @@ public class ConnectionStreams {
     }
 
     public Stream update(Stream streamToUpdate) throws IOException {
-        HttpClient.ApiResponse apiResponse = httpClient.updateRequest(PATH, streamToUpdate.getId(), streamToUpdate).exec();
+        Stream update = streamToUpdate.cloneMutableFields();
+        HttpClient.ApiResponse apiResponse = httpClient.updateRequest(PATH, streamToUpdate.getId(), update).exec();
         Stream updatedStream = JsonConverter.retrieveStreamFromJson(apiResponse.getJsonBody());
         return updatedStream;
     }

--- a/commons/src/main/java/com/pryv/model/Access.java
+++ b/commons/src/main/java/com/pryv/model/Access.java
@@ -216,4 +216,12 @@ public class Access extends ApiResource {
     return this;
   }
 
+  public Access cloneMutableFields() {
+    return new Access()
+            .setId(null)
+            .setName(this.name)
+            .setPermissions(this.permissions)
+            .setDeviceName(this.deviceName);
+  }
+
 }

--- a/commons/src/main/java/com/pryv/model/Event.java
+++ b/commons/src/main/java/com/pryv/model/Event.java
@@ -8,6 +8,7 @@ import com.pryv.utils.Cuid;
 
 import org.joda.time.DateTime;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -433,5 +434,19 @@ public class Event extends ApiResource {
   public Event setTrashed(Boolean trashed) {
     this.trashed = trashed;
     return this;
+  }
+
+  public Event cloneMutableFields() {
+    return new Event()
+            .setId(null)
+            .setStreamId(this.streamId)
+            .setTime(this.time)
+            .setType(this.type)
+            .setDuration(this.duration)
+            .setContent(this.content)
+            .setTags(this.tags)
+            .setDescription(this.description)
+            .setClientData(this.clientData)
+            .setTrashed(this.trashed);
   }
 }

--- a/commons/src/main/java/com/pryv/model/Event.java
+++ b/commons/src/main/java/com/pryv/model/Event.java
@@ -8,7 +8,6 @@ import com.pryv.utils.Cuid;
 
 import org.joda.time.DateTime;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;

--- a/commons/src/main/java/com/pryv/model/Stream.java
+++ b/commons/src/main/java/com/pryv/model/Stream.java
@@ -352,4 +352,14 @@ public class Stream extends ApiResource {
     return this;
   }
 
+  public Stream cloneMutableFields() {
+    return new Stream()
+            .setId(null)
+            .setParentId(this.parentId)
+            .setName(this.name)
+            .setTrashed(this.trashed)
+            .setSingleActivity(this.singleActivity)
+            .setClientData(this.clientData);
+  }
+
 }

--- a/commons/src/test/java/com/pryv/unit/AccessTest.java
+++ b/commons/src/test/java/com/pryv/unit/AccessTest.java
@@ -1,0 +1,37 @@
+package com.pryv.unit;
+
+import com.pryv.model.Access;
+
+import org.junit.Test;
+
+import java.util.HashSet;
+
+import static org.junit.Assert.assertNull;
+
+/**
+ * Created by thiebaudmodoux on 15.11.17.
+ */
+
+public class AccessTest {
+    @Test
+    public void testCloneMutableFields() {
+        Access immutableAccess = new Access();
+        immutableAccess.setId("immutable");
+        immutableAccess.setToken("immutable");
+        immutableAccess.setType("immutable");
+        immutableAccess.setCreated(0.0);
+        immutableAccess.setCreatedBy("immutable");
+        immutableAccess.setModified(0.0);
+        immutableAccess.setModifiedBy("immutable");
+        immutableAccess.setLastUsed(0.0);
+        Access mutableAccess = immutableAccess.cloneMutableFields();
+        assertNull(mutableAccess.getId());
+        assertNull(mutableAccess.getToken());
+        assertNull(mutableAccess.getType());
+        assertNull(mutableAccess.getCreated());
+        assertNull(mutableAccess.getCreatedBy());
+        assertNull(mutableAccess.getModified());
+        assertNull(mutableAccess.getModifiedBy());
+        assertNull(mutableAccess.getLastUsed());
+    }
+}

--- a/commons/src/test/java/com/pryv/unit/EventTest.java
+++ b/commons/src/test/java/com/pryv/unit/EventTest.java
@@ -1,5 +1,6 @@
 package com.pryv.unit;
 
+import com.pryv.model.Attachment;
 import com.pryv.model.Event;
 import com.pryv.util.TestUtils;
 
@@ -7,6 +8,7 @@ import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
@@ -83,6 +85,24 @@ public class EventTest {
   @Test
   public void testFullConstructor() {
     TestUtils.checkEvent(testEvent, testEvent);
+  }
+
+  @Test
+  public void testCloneMutableFields() {
+    Event immutableEvent = new Event();
+    immutableEvent.setId("immutable");
+    immutableEvent.setCreated(0.0);
+    immutableEvent.setCreatedBy("immutable");
+    immutableEvent.setModified(0.0);
+    immutableEvent.setModifiedBy("immutable");
+    immutableEvent.setAttachments(new HashSet<Attachment>());
+    Event mutableEvent = immutableEvent.cloneMutableFields();
+    assertNull(mutableEvent.getId());
+    assertNull(mutableEvent.getCreated());
+    assertNull(mutableEvent.getCreatedBy());
+    assertNull(mutableEvent.getModified());
+    assertNull(mutableEvent.getModifiedBy());
+    assertNull(mutableEvent.getAttachments());
   }
 
   /**

--- a/commons/src/test/java/com/pryv/unit/StreamTest.java
+++ b/commons/src/test/java/com/pryv/unit/StreamTest.java
@@ -5,6 +5,11 @@ import com.pryv.model.Stream;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -61,6 +66,24 @@ public class StreamTest {
     Stream parent = new Stream("parentId", null)
             .addChildStream(child);
     assertFalse(parent.hasChild("blop"));
+  }
+
+  @Test
+  public void testCloneMutableFields() {
+    Stream immutableStream = new Stream();
+    immutableStream.setId("immutable");
+    immutableStream.setCreated(0.0);
+    immutableStream.setCreatedBy("immutable");
+    immutableStream.setModified(0.0);
+    immutableStream.setModifiedBy("immutable");
+    immutableStream.setChildren(new HashSet<Stream>());
+    Stream mutableStream = immutableStream.cloneMutableFields();
+    assertNull(mutableStream.getId());
+    assertNull(mutableStream.getCreated());
+    assertNull(mutableStream.getCreatedBy());
+    assertNull(mutableStream.getModified());
+    assertNull(mutableStream.getModifiedBy());
+    assertNull(mutableStream.getChildren());
   }
 
   private void checkStreamParams(Stream pStream) {


### PR DESCRIPTION
Core now reject update calls that include modification of read-only fields (such as id, modified, created...). Thus, we also want to remove the possibility of creating such requests through the lib.

It is done by cloning the update resource but considering only the mutable fields, thus ignoring the read-only ones (white list strategy).